### PR TITLE
fix: uncomment gas calculation cause it's working now. #lsc-42

### DIFF
--- a/internal/submit/tx_sender.go
+++ b/internal/submit/tx_sender.go
@@ -84,13 +84,10 @@ func (txs *TxSender) Send(ctx context.Context, msgs []sdk.Msg) error {
 		WithAccountNumber(account.AccountNumber).
 		WithSequence(account.Sequence)
 
-	// TODO: https://p2pvalidator.atlassian.net/browse/LSC-42
-	//gasNeeded, err := txs.calculateGas(ctx, txf, msgs...)
-	//if err != nil {
-	//	return fmt.Errorf("error calculating gas: %w", err)
-	//}
-
-	gasNeeded := uint64(50000000)
+	gasNeeded, err := txs.calculateGas(ctx, txf, msgs...)
+	if err != nil {
+		return fmt.Errorf("error calculating gas: %w", err)
+	}
 
 	txf = txf.
 		WithGas(gasNeeded).


### PR DESCRIPTION
So gas calculation now working (checked it) because in gaia-wasm-zone missing msg handler was added.
