### PR TITLE
fix/sub-events-doubling

### DIFF
--- a/internal/raw/subscribe_events.go
+++ b/internal/raw/subscribe_events.go
@@ -7,6 +7,7 @@ import (
 	neutrontypes "github.com/neutron-org/neutron/x/interchainqueries/types"
 	rpcclient "github.com/tendermint/tendermint/rpc/client/http"
 	coretypes "github.com/tendermint/tendermint/rpc/core/types"
+	"github.com/tendermint/tendermint/types"
 )
 
 const websocketPath = "/websocket"
@@ -36,5 +37,5 @@ func Subscribe(ctx context.Context, subscriberName string, rpcAddress string, qu
 // SubscribeQuery describes query to filter out events by module and action.
 func SubscribeQuery(zoneId string) string {
 	// TODO: add zoneId to the query when zone id passing is implemented
-	return fmt.Sprintf("message.module='%s' AND message.action='%s'", neutrontypes.ModuleName, neutrontypes.AttributeValueQuery)
+	return fmt.Sprintf("message.module='%s' AND message.action='%s' AND tm.event='%s'", neutrontypes.ModuleName, neutrontypes.AttributeValueQuery, types.EventNewBlockHeader)
 }


### PR DESCRIPTION
https://p2pvalidator.atlassian.net/browse/LSC-107

The reason of events "doubling" is the fact that tendermint [fires](https://github.com/tendermint/tendermint/blob/331860c2a8c406fa89575165322b963925fb38c5/internal/state/execution.go#L302) two various events on each block: [NewBlock](https://github.com/tendermint/tendermint/blob/331860c2a8c406fa89575165322b963925fb38c5/internal/state/execution.go#L608) and [NewBlockHeader](https://github.com/tendermint/tendermint/blob/331860c2a8c406fa89575165322b963925fb38c5/internal/state/execution.go#L616), and we in the Subscribe don't specify the event type we expect. Moreover, there is [a lot of different events](https://github.com/tendermint/tendermint/blob/v0.34.19/types/events.go#L13) and we definitely don't want to be subscribed to them all (or at least in the future we will need to distinguish between them and handle them in different ways). So, specifying the concrete event type (NewBlockHeader because it's lighter than the NewBlock) in the Subscribe query makes the trick.