### PR TITLE
Chore: clean relayer storage before dev run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-dev:
+dev: clean
 	go run ./cmd/neutron_query_relayer/
 
 clean:


### PR DESCRIPTION
Never again forget cleaning up storage before running relayer!