### PR TITLE
feat: support all possible keyrings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -41,6 +41,11 @@ func NewDefaultSubscriber(logger *zap.Logger, cfg config.NeutronQueryRelayerConf
 	if err != nil {
 		logger.Fatal("failed to get a NewSubscriber", zap.Error(err))
 	}
+	logger.Debug("Subscribed successfully",
+		zap.String("rpc", cfg.NeutronChain.RPCAddr),
+		zap.String("rest", cfg.NeutronChain.RESTAddr),
+		zap.Strings("registries", cfg.Registry.Addresses),
+	)
 
 	return subscriber
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -113,13 +113,6 @@ func NewDefaultRelayer(
 		logger.Error("failed to loadChains", zap.Error(err))
 	}
 
-	if cfg.NeutronChain.KeyringBackend == keyring.BackendMemory {
-		_, err := neutronChain.ChainProvider.RestoreKey(keyName, cfg.NeutronChain.SignKeySeed, sdk.CoinType)
-		if err != nil {
-			logger.Fatal("cannot add key to the memory keyring", zap.Error(err))
-		}
-	}
-
 	var (
 		proofSubmitter       = submit.NewSubmitterImpl(txSender, cfg.AllowKVCallbacks, neutronChain.PathEnd.ClientID)
 		txQuerier            = txquerier.NewTXQuerySrv(targetQuerier.Client)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -72,12 +72,8 @@ func NewDefaultRelayer(
 	}
 
 	codec := raw.MakeCodecDefault()
-	keybase, err := submit.TestKeybase(cfg.NeutronChain.ChainID, cfg.NeutronChain.HomeDir)
-	if err != nil {
-		logger.Fatal("cannot initialize keybase", zap.Error(err))
-	}
 
-	txSender, err := submit.NewTxSender(ctx, neutronClient, codec.Marshaller, keybase, *cfg.NeutronChain, logger)
+	txSender, err := submit.NewTxSender(ctx, neutronClient, codec.Marshaller, *cfg.NeutronChain, logger)
 	if err != nil {
 		logger.Fatal("cannot create tx sender", zap.Error(err))
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,6 @@ type NeutronChainConfig struct {
 	HomeDir         string        `required:"true" split_words:"true"`
 	SignKeyName     string        `split_words:"true"`
 	SignKeySeed     string        `split_words:"true"`
-	SignKeyHDPath   string        `split_words:"true" default:""`
 	Timeout         time.Duration `required:"true" split_words:"true"`
 	GasPrices       string        `required:"true" split_words:"true"`
 	GasLimit        uint64        `split_words:"true" default:"0"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,21 +26,24 @@ type NeutronQueryRelayerConfig struct {
 const EnvPrefix string = "RELAYER"
 
 type NeutronChainConfig struct {
-	RPCAddr        string        `required:"true" split_words:"true"`
-	RESTAddr       string        `required:"true" split_words:"true"`
-	ChainID        string        `required:"true" split_words:"true"`
-	HomeDir        string        `required:"true" split_words:"true"`
-	SignKeyName    string        `required:"true" split_words:"true"`
-	Timeout        time.Duration `required:"true" split_words:"true"`
-	GasPrices      string        `required:"true" split_words:"true"`
-	GasLimit       uint64        `split_words:"true" default:"0"`
-	GasAdjustment  float64       `required:"true" split_words:"true"`
-	ConnectionID   string        `required:"true" split_words:"true"`
-	ClientID       string        `required:"true" split_words:"true"`
-	Debug          bool          `required:"true" split_words:"true"`
-	KeyringBackend string        `required:"true" split_words:"true"`
-	OutputFormat   string        `required:"true" split_words:"true"`
-	SignModeStr    string        `required:"true" split_words:"true"`
+	RPCAddr         string        `required:"true" split_words:"true"`
+	RESTAddr        string        `required:"true" split_words:"true"`
+	ChainID         string        `required:"true" split_words:"true"`
+	HomeDir         string        `required:"true" split_words:"true"`
+	SignKeyName     string        `split_words:"true"`
+	SignKeySeed     string        `split_words:"true"`
+	SignKeyHDPath   string        `split_words:"true" default:""`
+	Timeout         time.Duration `required:"true" split_words:"true"`
+	GasPrices       string        `required:"true" split_words:"true"`
+	GasLimit        uint64        `split_words:"true" default:"0"`
+	GasAdjustment   float64       `required:"true" split_words:"true"`
+	ConnectionID    string        `required:"true" split_words:"true"`
+	ClientID        string        `required:"true" split_words:"true"`
+	Debug           bool          `required:"true" split_words:"true"`
+	KeyringBackend  string        `required:"true" split_words:"true"`
+	KeyringPassword string        `split_words:"true"`
+	OutputFormat    string        `required:"true" split_words:"true"`
+	SignModeStr     string        `required:"true" split_words:"true"`
 }
 
 type TargetChainConfig struct {

--- a/internal/relay/config.go
+++ b/internal/relay/config.go
@@ -66,12 +66,5 @@ func getChain(logger *zap.Logger, cfg cosmos.CosmosProviderConfig, homepath stri
 		return nil, fmt.Errorf("failed to build ChainProvider for %w", err)
 	}
 
-	// Without this hack it doesn't want to work with normal home dir layout for some reason.
-	provConcrete, ok := prov.(*cosmos.CosmosProvider)
-	if !ok {
-		return nil, fmt.Errorf("failed to patch CosmosProvider config (type cast failed)")
-	}
-	provConcrete.Config.KeyDirectory = homepath
-
 	return relayer.NewChain(logger, prov, debug), nil
 }

--- a/internal/relay/config.go
+++ b/internal/relay/config.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 
 	"github.com/cosmos/relayer/v2/relayer"
 	"github.com/cosmos/relayer/v2/relayer/provider/cosmos"
@@ -13,11 +14,11 @@ import (
 
 func GetNeutronChain(logger *zap.Logger, cfg *config.NeutronChainConfig) (*relayer.Chain, error) {
 	provCfg := cosmos.CosmosProviderConfig{
-		Key:            cfg.SignKeyName,
+		Key:            "",
 		ChainID:        cfg.ChainID,
 		RPCAddr:        cfg.RPCAddr,
 		AccountPrefix:  neutronapp.Bech32MainPrefix,
-		KeyringBackend: cfg.KeyringBackend,
+		KeyringBackend: keyring.BackendMemory,
 		GasAdjustment:  cfg.GasAdjustment,
 		GasPrices:      cfg.GasPrices,
 		Debug:          cfg.Debug,
@@ -35,13 +36,11 @@ func GetNeutronChain(logger *zap.Logger, cfg *config.NeutronChainConfig) (*relay
 
 func GetTargetChain(logger *zap.Logger, cfg *config.TargetChainConfig) (*relayer.Chain, error) {
 	provCfg := cosmos.CosmosProviderConfig{
-		Key:           "",
-		ChainID:       cfg.ChainID,
-		RPCAddr:       cfg.RPCAddr,
-		AccountPrefix: cfg.AccountPrefix,
-		// we don't have any needs in keys for target chain
-		// but since "KeyringBackend" can't be an empty string we explicitly set it to "test" value to avoid errors
-		KeyringBackend: "test",
+		Key:            "",
+		ChainID:        cfg.ChainID,
+		RPCAddr:        cfg.RPCAddr,
+		AccountPrefix:  cfg.AccountPrefix,
+		KeyringBackend: keyring.BackendMemory,
 		GasAdjustment:  0.0,
 		GasPrices:      "",
 		Debug:          cfg.Debug,

--- a/internal/relay/config.go
+++ b/internal/relay/config.go
@@ -3,7 +3,6 @@ package relay
 import (
 	"fmt"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-
 	"github.com/cosmos/relayer/v2/relayer"
 	"github.com/cosmos/relayer/v2/relayer/provider/cosmos"
 	"go.uber.org/zap"
@@ -12,13 +11,13 @@ import (
 	neutronapp "github.com/neutron-org/neutron/app"
 )
 
-func GetNeutronChain(logger *zap.Logger, cfg *config.NeutronChainConfig) (*relayer.Chain, error) {
+func GetNeutronChain(logger *zap.Logger, cfg *config.NeutronChainConfig, keyName string) (*relayer.Chain, error) {
 	provCfg := cosmos.CosmosProviderConfig{
-		Key:            "",
+		Key:            keyName,
 		ChainID:        cfg.ChainID,
 		RPCAddr:        cfg.RPCAddr,
 		AccountPrefix:  neutronapp.Bech32MainPrefix,
-		KeyringBackend: keyring.BackendMemory,
+		KeyringBackend: cfg.KeyringBackend,
 		GasAdjustment:  cfg.GasAdjustment,
 		GasPrices:      cfg.GasPrices,
 		Debug:          cfg.Debug,

--- a/internal/submit/tx_sender.go
+++ b/internal/submit/tx_sender.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"strings"
 	"sync"
 
@@ -48,12 +49,17 @@ type TxSender struct {
 	logger        *zap.Logger
 }
 
-func TestKeybase(chainID string, keyringRootDir string) (keyring.Keyring, error) {
-	keybase, err := keyring.New(chainID, "test", keyringRootDir, nil)
+func NewKeybase(
+	chainID string,
+	keyringRootDir string,
+	keyringBackend string,
+	keyringPassword string,
+) (keyring.Keyring, error) {
+	passReader := strings.NewReader(keyringPassword)
+	keybase, err := keyring.New(chainID, keyringBackend, keyringRootDir, passReader)
 	if err != nil {
 		return keybase, fmt.Errorf("error creating keybase for chainId=%s and keyringRootDir=%s: %w", chainID, keyringRootDir, err)
 	}
-
 	return keybase, nil
 }
 
@@ -61,11 +67,34 @@ func NewTxSender(
 	ctx context.Context,
 	rpcClient rpcclient.Client,
 	marshaller codec.ProtoCodecMarshaler,
-	keybase keyring.Keyring,
 	cfg config.NeutronChainConfig,
 	logger *zap.Logger,
 ) (*TxSender, error) {
 	txConfig := authtxtypes.NewTxConfig(marshaller, authtxtypes.DefaultSignModes)
+
+	keybase, err := NewKeybase(
+		cfg.ChainID,
+		cfg.HomeDir,
+		cfg.KeyringBackend,
+		cfg.KeyringPassword,
+	)
+	if err != nil {
+		logger.Fatal("cannot initialize keybase", zap.Error(err))
+	}
+
+	keyName := cfg.SignKeyName
+
+	// If the keybase is set to "memory" then we expect the seed to be passed via environment variable and we need to
+	// add the key to the in-memory keybase
+	if cfg.KeyringBackend == keyring.BackendMemory {
+		// For in-memory key we ignore the name provided by user (so it might be (and actually should be) left empty)
+		keyName = "sign_key"
+		err = addKeyToTheKeybase(keybase, keyName, cfg.SignKeySeed, cfg.SignKeyHDPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	baseTxf := tx.Factory{}.
 		WithKeybase(keybase).
 		WithSignMode(signing.SignMode_SIGN_MODE_DIRECT).
@@ -82,12 +111,12 @@ func NewTxSender(
 		baseTxf:     baseTxf,
 		rpcClient:   rpcClient,
 		chainID:     cfg.ChainID,
-		signKeyName: cfg.SignKeyName,
+		signKeyName: keyName,
 		gasPrices:   cfg.GasPrices,
 		gasLimit:    cfg.GasLimit,
 		logger:      logger,
 	}
-	err := txs.refreshAccountInfo()
+	err = txs.refreshAccountInfo()
 	if err != nil {
 		return nil, fmt.Errorf("failed to init tx sender: %w", err)
 	}
@@ -280,4 +309,15 @@ func (txs *TxSender) buildSimulationTx(txf tx.Factory, msgs ...sdk.Msg) ([]byte,
 	}
 	simReq := txtypes.SimulateRequest{TxBytes: bz}
 	return simReq.Marshal()
+}
+
+func addKeyToTheKeybase(keybase keyring.Keyring, keyName, signKeySeed, signKeyHdPath string) error {
+	if len(signKeyHdPath) == 0 {
+		signKeyHdPath = hd.CreateHDPath(sdk.CoinType, 0, 0).String()
+	}
+	_, err := keybase.NewAccount(keyName, signKeySeed, "", signKeyHdPath, hd.Secp256k1)
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This PR contains changes intended to add support for all possible keyrings to the query-relayer.

Changes:
1. It's now possible to use any keyring supported by keyring lib.
2. Memory keyring is supported in a way where user can provide mnemonic via env variable.
    1. in such case, there is no need to require the keyname to be passed from the user
    1. it's also a bad idea in my opinion to use any default value for keyname option since it might affect existing accounts in case of the wrong configuration
    1. that's why keyname can be modified during execution and all users of the keyring should take not the one from config but the one from keyring initialization
3. kwallet hasn't been tested properly since it's some old-ass almost-deprecated UI-with-KDE-only thing that even has no tests in the [original go library](https://github.com/99designs/keyring). Not sure if somebody in Cosmos even uses it, I'd assume not. Even if yes, it's a bad idea to use it in query-relayer deployment. But it should hopefully work anyway.
4. Config modified in a way where it has a group of dependent parameters. Those depend on keyring_backend type mostly and it's covered in docs.
5. The hack of substitution of the KeyDirectory in the CosmosProvider before initialization is replaced with the hack of substitution of the Kering itself after the initialization. It's done for multiple reasons:
    1. The abstraction is broken here. CosmosProvider should accept arbitrary keyring instead of making it by itself. That's why I see the hack with the substitution of the whole keyring to be a more proper approach.
    2. The way CosmosProvider creates Keyring is also not flexible (the necessity of KeyDirectory is the first proof; the second one is an absence of the ability to provide HDPath when creating the key in the implicitly created Keyring)
6. In the relay/config.go both chains are created with empty memory Keyrings instead of "test"/configured one. The reasons are:
    1. Memory is a better placeholder for Keyring than "test" since it just creates in-memory empty object without any link to the outside environment
    2. The Neutron CosmosProvider is created with an empty Keyring explicitly because we're going to replace it further. Passing "real" values would increase the confusion and probability of errors in my opinion.