### PR TITLE
fix: fixed error with trusted headers inconsistency

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -121,6 +121,7 @@ func NewDefaultRelayer(
 		trustedHeaderFetcher = trusted_headers.NewTrustedHeaderFetcher(neutronChain, targetChain, logRegistry.Get(TrustedHeadersFetcherContext))
 		txProcessor          = txprocessor.NewTxProcessor(trustedHeaderFetcher, st, proofSubmitter, logRegistry.Get(TxProcessorContext))
 		kvProcessor          = kvprocessor.NewKVProcessor(
+			trustedHeaderFetcher,
 			targetQuerier,
 			cfg.MinKvUpdatePeriod,
 			logRegistry.Get(KVProcessorContext),

--- a/internal/kvprocessor/kvprocessor.go
+++ b/internal/kvprocessor/kvprocessor.go
@@ -152,7 +152,7 @@ func (p *KVProcessor) getSrcChainHeader(ctx context.Context, height int64) (ibce
 	var srcHeader ibcexported.Header
 	if err := retry.Do(func() error {
 		var err error
-		srcHeader, err = p.trustedHeaderFetcher.FetchBest(ctx, uint64(height))
+		srcHeader, err = p.trustedHeaderFetcher.FetchTrustedHeaderForHeight(ctx, uint64(height))
 		return err
 	}, retry.Context(ctx), relayer.RtyAtt, relayer.RtyDel, relayer.RtyErr, retry.OnRetry(func(n uint, err error) {
 		p.logger.Info(

--- a/internal/kvprocessor/kvprocessor.go
+++ b/internal/kvprocessor/kvprocessor.go
@@ -23,16 +23,18 @@ import (
 // KVProcessor is implementation of relay.KVProcessor that processes event query KV type.
 // Obtains the proof for a query we need to process, and sends it to  the neutron
 type KVProcessor struct {
-	querier           *tmquerier.Querier
-	minKVUpdatePeriod uint64
-	logger            *zap.Logger
-	submitter         relay.Submitter
-	storage           relay.Storage
-	targetChain       *relayer.Chain
-	neutronChain      *relayer.Chain
+	trustedHeaderFetcher relay.TrustedHeaderFetcher
+	querier              *tmquerier.Querier
+	minKVUpdatePeriod    uint64
+	logger               *zap.Logger
+	submitter            relay.Submitter
+	storage              relay.Storage
+	targetChain          *relayer.Chain
+	neutronChain         *relayer.Chain
 }
 
 func NewKVProcessor(
+	trustedHeaderFetcher relay.TrustedHeaderFetcher,
 	querier *tmquerier.Querier,
 	minKVUpdatePeriod uint64,
 	logger *zap.Logger,
@@ -41,13 +43,14 @@ func NewKVProcessor(
 	targetChain *relayer.Chain,
 	neutronChain *relayer.Chain) relay.KVProcessor {
 	return &KVProcessor{
-		querier:           querier,
-		minKVUpdatePeriod: minKVUpdatePeriod,
-		logger:            logger,
-		submitter:         submitter,
-		storage:           storage,
-		targetChain:       targetChain,
-		neutronChain:      neutronChain,
+		trustedHeaderFetcher: trustedHeaderFetcher,
+		querier:              querier,
+		minKVUpdatePeriod:    minKVUpdatePeriod,
+		logger:               logger,
+		submitter:            submitter,
+		storage:              storage,
+		targetChain:          targetChain,
+		neutronChain:         neutronChain,
 	}
 }
 
@@ -140,7 +143,7 @@ func (p *KVProcessor) submitKVWithProof(
 		return fmt.Errorf("could not submit proof: %w", err)
 	}
 	neutronmetrics.AddSuccessProof(string(neutrontypes.InterchainQueryTypeKV), time.Since(st).Seconds())
-	p.logger.Info("proof for query_id submitted successfully", zap.Uint64("query_id", queryID))
+	p.logger.Info("proof for query_id submitted successfully", zap.Uint64("query_id", queryID), zap.Uint64("remote_height", uint64(height-1)), zap.Uint64("trusted_header_height", srcHeader.GetHeight().GetRevisionHeight()))
 	return nil
 }
 
@@ -149,7 +152,7 @@ func (p *KVProcessor) getSrcChainHeader(ctx context.Context, height int64) (ibce
 	var srcHeader ibcexported.Header
 	if err := retry.Do(func() error {
 		var err error
-		srcHeader, err = p.targetChain.ChainProvider.GetIBCUpdateHeader(ctx, height, p.neutronChain.ChainProvider, p.neutronChain.PathEnd.ClientID)
+		srcHeader, err = p.trustedHeaderFetcher.FetchBest(ctx, uint64(height))
 		return err
 	}, retry.Context(ctx), relayer.RtyAtt, relayer.RtyDel, relayer.RtyErr, retry.OnRetry(func(n uint, err error) {
 		p.logger.Info(

--- a/internal/relay/trusted_headers.go
+++ b/internal/relay/trusted_headers.go
@@ -9,7 +9,9 @@ import (
 
 // TrustedHeaderFetcher able to get trusted headers for a given height
 type TrustedHeaderFetcher interface {
-	// Fetch returns two trusted Headers for height and height+1 packed into *codectypes.Any value
-	Fetch(ctx context.Context, height uint64) (header *codectypes.Any, nextHeader *codectypes.Any, err error)
-	FetchBest(ctx context.Context, height uint64) (exported.Header, error)
+	// FetchTrustedHeadersForHeights returns two trusted Headers for height and height+1 packed into *codectypes.Any value
+	FetchTrustedHeadersForHeights(ctx context.Context, height uint64) (header *codectypes.Any, nextHeader *codectypes.Any, err error)
+
+	// FetchTrustedHeaderForHeight returns only one trusted Header for specified height
+	FetchTrustedHeaderForHeight(ctx context.Context, height uint64) (exported.Header, error)
 }

--- a/internal/relay/trusted_headers.go
+++ b/internal/relay/trusted_headers.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"context"
+	"github.com/cosmos/ibc-go/v3/modules/core/exported"
 
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 )
@@ -10,4 +11,5 @@ import (
 type TrustedHeaderFetcher interface {
 	// Fetch returns two trusted Headers for height and height+1 packed into *codectypes.Any value
 	Fetch(ctx context.Context, height uint64) (header *codectypes.Any, nextHeader *codectypes.Any, err error)
+	FetchBest(ctx context.Context, height uint64) (exported.Header, error)
 }

--- a/internal/txprocessor/txprocessor.go
+++ b/internal/txprocessor/txprocessor.go
@@ -110,7 +110,7 @@ func (r TXProcessor) txToBlock(ctx context.Context, tx relay.Transaction) (*neut
 }
 
 func (r TXProcessor) prepareHeaders(ctx context.Context, txStruct relay.Transaction) (packedHeader *codectypes.Any, packedNextHeader *codectypes.Any, err error) {
-	packedHeader, packedNextHeader, err = r.trustedHeaderFetcher.Fetch(ctx, txStruct.Height)
+	packedHeader, packedNextHeader, err = r.trustedHeaderFetcher.FetchTrustedHeadersForHeights(ctx, txStruct.Height)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get header for src chain: %w", err)
 	}


### PR DESCRIPTION
the root of problem.
cosmos-sdk finction `GetIBCUpdateHeader` fetches latest trusted header for any given height, which sometimes leads to the error like
```
{"level":"error","ts":"2022-11-03T07:26:13.625712422+02:00","caller":"relay/relayer.go:91","msg":"could not process message","context":"relayer","query_id":0,"error":"could not submit proof: error calculating gas: no result in simulation response with log=\ngithub.com/cosmos/cosmos-sdk/baseapp.gRPCErrorToSDKError\n\tgithub.com/cosmos/cosmos-sdk@v0.45.5/baseapp/abci.go:590\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).handleQueryGRPC\n\tgithub.com/cosmos/cosmos-sdk@v0.45.5/baseapp/abci.go:579\ngithub.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).Query\n\tgithub.com/cosmos/cosmos-sdk@v0.45.5/baseapp/abci.go:421\ngithub.com/tendermint/tendermint/abci/client.(*localClient).QuerySync\n\tgithub.com/tendermint/tendermint@v0.34.19/abci/client/local_client.go:256\ngithub.com/tendermint/tendermint/proxy.(*appConnQuery).QuerySync\n\tgithub.com/tendermint/tendermint@v0.34.19/proxy/app_conn.go:159\ngithub.com/tendermint/tendermint/rpc/core.ABCIQuery\n\tgithub.com/tendermint/tendermint@v0.34.19/rpc/core/abci.go:20\nreflect.Value.call\n\treflect/value.go:584\nreflect.Value.Call\n\treflect/value.go:368\ngithub.com/tendermint/tendermint/rpc/jsonrpc/server.makeJSONRPCHandler.func1\n\tgithub.com/tendermint/tendermint@v0.34.19/rpc/jsonrpc/server/http_json_handler.go:96\ngithub.com/tendermint/tendermint/rpc/jsonrpc/server.handleInvalidJSONRPCPaths.func1\n\tgithub.com/tendermint/tendermint@v0.34.19/rpc/jsonrpc/server/http_json_handler.go:122\nnet/http.HandlerFunc.ServeHTTP\n\tnet/http/server.go:2109\nnet/http.(*ServeMux).ServeHTTP\n\tnet/http/server.go:2487\ngithub.com/rs/cors.(*Cors).Handler.func1\n\tgithub.com/rs/cors@v1.8.2/cors.go:231\nnet/http.HandlerFunc.ServeHTTP\n\tnet/http/server.go:2109\ngithub.com/tendermint/tendermint/rpc/jsonrpc/server.maxBytesHandler.ServeHTTP\n\tgithub.com/tendermint/tendermint@v0.34.19/rpc/jsonrpc/server/http_server.go:236\ngithub.com/tendermint/tendermint/rpc/jsonrpc/server.RecoverAndLogHandler.func1\n\tgithub.com/tendermint/tendermint@v0.34.19/rpc/jsonrpc/server/http_server.go:209\nnet/http.HandlerFunc.ServeHTTP\n\tnet/http/server.go:2109\nnet/http.serverHandler.ServeHTTP\n\tnet/http/server.go:2947\nnet/http.(*conn).serve\n\tnet/http/server.go:1991\nTrustedHeight {5 612768} must be less than header height {5 612768}: invalid header height: invalid request code=18","stacktrace":"github.com/neutron-org/neutron-query-relayer/internal/relay.(*Relayer).Run\n\t/home/foxpy/Work/neutron-query-relayer/internal/relay/relayer.go:91\nmain.main.func3\n\t/home/foxpy/Work/neutron-query-relayer/cmd/neutron_query_relayer/main.go:90"}
```
the main part 
`TrustedHeight {5 612768} must be less than header height {5 612768}`
we replaced `GetIBCUpdateHeader` with our TrustedHeaderFetcher.FetchBest`

Tested manually with setup
gaia - 5sec block
neutron - 1sec block
registered queries ~ 100, update period of each ~10
with `GetIBCUpdateHeader` the relayer throws the errors
with `FetchBest` the relayer works fine