### PR TITLE
chore: NTRN-268. Refactor trusted header fetcher interface in ICQ relayer

### DIFF
--- a/internal/kvprocessor/kvprocessor.go
+++ b/internal/kvprocessor/kvprocessor.go
@@ -154,7 +154,7 @@ func (p *KVProcessor) getSrcChainHeader(ctx context.Context, height int64) (ibce
 	var srcHeader ibcexported.Header
 	if err := retry.Do(func() error {
 		var err error
-		srcHeader, err = p.trustedHeaderFetcher.FetchTrustedHeaderForHeight(ctx, uint64(height))
+		srcHeader, err = p.trustedHeaderFetcher.Fetch(ctx, uint64(height))
 		return err
 	}, retry.Context(ctx), relayer.RtyAtt, relayer.RtyDel, relayer.RtyErr, retry.OnRetry(func(n uint, err error) {
 		p.logger.Info(

--- a/internal/relay/trusted_headers.go
+++ b/internal/relay/trusted_headers.go
@@ -4,15 +4,10 @@ import (
 	"context"
 
 	"github.com/cosmos/ibc-go/v3/modules/core/exported"
-
-	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 )
 
 // TrustedHeaderFetcher able to get trusted headers for a given height
 type TrustedHeaderFetcher interface {
-	// FetchTrustedHeadersForHeights returns two trusted Headers for height and height+1 packed into *codectypes.Any value
-	FetchTrustedHeadersForHeights(ctx context.Context, height uint64) (header *codectypes.Any, nextHeader *codectypes.Any, err error)
-
-	// FetchTrustedHeaderForHeight returns only one trusted Header for specified height
-	FetchTrustedHeaderForHeight(ctx context.Context, height uint64) (exported.Header, error)
+	// Fetch returns only one trusted Header for specified height
+	Fetch(ctx context.Context, height uint64) (exported.Header, error)
 }

--- a/internal/txprocessor/txprocessor.go
+++ b/internal/txprocessor/txprocessor.go
@@ -181,7 +181,7 @@ func (r TXProcessor) txToBlock(ctx context.Context, tx relay.Transaction) (*neut
 // since LastResultsHash is root hash of all results from the txs from the previous block (delivery proof)
 //
 // Arguments:
-// `height` - remote chain block height X = transaction with such block height
+// `txStruct` - Transaction that represents single tx with height
 func (r TXProcessor) prepareHeaders(ctx context.Context, txStruct relay.Transaction) (
 	packedHeader *codectypes.Any, packedNextHeader *codectypes.Any, err error) {
 


### PR DESCRIPTION
**Summary**

[Here](https://github.com/neutron-org/neutron-query-relayer/blob/main/internal/relay/trusted_headers.go) we have two almost similar functions defined. Since it is very confusing, it should be refactored.

**DoD**
- [x] FetchTrustedHeaderForHeight is used for KV query submission. It should be renamed into Fetch.
- [x] FetchTrustedHeadersForHeights is used for TX query submission. It should be deleted from trusted header fetcher interface and rewritten as helper function inside TX submission module.

Closes https://p2pvalidator.atlassian.net/browse/NTRN-268

Test run: https://github.com/neutron-org/neutron-tests/actions/runs/3947735784