### PR TITLE
chore: Remove tendermint workaround proxy

### DIFF
--- a/cmd/neutron_query_relayer/cmd/start.go
+++ b/cmd/neutron_query_relayer/cmd/start.go
@@ -68,7 +68,7 @@ func startRelayer() {
 	logger := logRegistry.Get(mainContext)
 	logger.Info("neutron-query-relayer starts...")
 
-	cfg, err := config.NewNeutronQueryRelayerConfig(logger)
+	cfg, err := config.NewNeutronQueryRelayerConfig()
 	if err != nil {
 		logger.Fatal("cannot initialize relayer config", zap.Error(err))
 	}

--- a/go.sum
+++ b/go.sum
@@ -1866,8 +1866,6 @@ github.com/ncw/swift v1.0.47/go.mod h1:23YIA4yWVnGwv2dQlN4bB7egfYX6YLn0Yo/S6zZO/
 github.com/neilotoole/errgroup v0.1.5/go.mod h1:Q2nLGf+594h0CLBs/Mbg6qOr7GtqDK7C2S41udRnToE=
 github.com/neilotoole/errgroup v0.1.6/go.mod h1:Q2nLGf+594h0CLBs/Mbg6qOr7GtqDK7C2S41udRnToE=
 github.com/networkplumbing/go-nft v0.2.0/go.mod h1:HnnM+tYvlGAsMU7yoYwXEVLLiDW9gdMmb5HoGcwpuQs=
-github.com/neutron-org/neutron v0.2.1-0.20230315100049-f1e847c12971 h1:9FVZYyGU+tImSyLjzoN4tvB8wwzOSXwT57ornmy8mxs=
-github.com/neutron-org/neutron v0.2.1-0.20230315100049-f1e847c12971/go.mod h1:3qGjV/DUNieLHbxzxJoI/6A7xDbUevf+Mg2Lr6l7Mb4=
 github.com/neutron-org/neutron v0.2.1-0.20230316195435-636a5b05e052 h1:Jg6N+TAW2q6aVGVfU58iMT8rkgB6SmPZP3bpvUXgbT0=
 github.com/neutron-org/neutron v0.2.1-0.20230316195435-636a5b05e052/go.mod h1:3qGjV/DUNieLHbxzxJoI/6A7xDbUevf+Mg2Lr6l7Mb4=
 github.com/neutron-org/neutron-logger v0.0.0-20221027125151-535167f2dd73 h1:E1+ittfo/+u2/TgPzOzjjGXCmP3k2+L38+woz6RJvbk=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,13 +2,7 @@ package config
 
 import (
 	"fmt"
-	"net"
-	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"time"
-
-	"go.uber.org/zap"
 
 	"github.com/kelseyhightower/envconfig"
 
@@ -56,7 +50,7 @@ type TargetChainConfig struct {
 	OutputFormat string        `split_words:"true" default:"json"`
 }
 
-func NewNeutronQueryRelayerConfig(logger *zap.Logger) (NeutronQueryRelayerConfig, error) {
+func NewNeutronQueryRelayerConfig() (NeutronQueryRelayerConfig, error) {
 	var cfg NeutronQueryRelayerConfig
 
 	err := envconfig.Process(EnvPrefix, &cfg)
@@ -64,93 +58,5 @@ func NewNeutronQueryRelayerConfig(logger *zap.Logger) (NeutronQueryRelayerConfig
 		return cfg, fmt.Errorf("could not read config from env: %w", err)
 	}
 
-	proxy, err := setupProxy(cfg.NeutronChain.RPCAddr, logger)
-	if err != nil {
-		return cfg, fmt.Errorf("could not start tendermint-workaround reverse proxy for Neutron RPC %s: %w", cfg.NeutronChain.RPCAddr, err)
-	}
-	cfg.NeutronChain.RPCAddr = proxy
-
-	proxy, err = setupProxy(cfg.TargetChain.RPCAddr, logger)
-	if err != nil {
-		return cfg, fmt.Errorf("could not start tendermint-workaround reverse proxy for Target RPC %s: %w", cfg.TargetChain.RPCAddr, err)
-	}
-	cfg.TargetChain.RPCAddr = proxy
-
 	return cfg, nil
-}
-
-/*
- * this function spawns a workaround proxy which fights bug fixed in tendermint on this commit:
- * https://github.com/tendermint/tendermint/commit/8e90d294ca7cb2460bd31cc544639a6ea7efbe9d
- * ⠀⠀⠀⠀⣾⠱⣼⣿⣿⣿⣿⣷⣿⣿⣿⡿⢓⣽⣿⣿⣿⣿⣿⣿⣿⣿⣿⢿⣌⢄⠑⠀⠀⢀⠀⠀⠀⣀⠈⠀⠀⠀⠀⠐⠗⡷⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡷⣧⠌⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- * ⠀⠀⣠⣮⣿⢎⣿⣿⣿⣿⣿⣿⣿⠷⡁⠆⢱⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣮⣎⣈⣈⣌⣿⣌⣌⣩⢌⠀⠀⠀⠀⠀⠀⠐⠱⣷⣿⣿⣿⣿⣿⣿⠟⣿⢀⠐⠏⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- * ⠀⣠⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠓⠀⢀⣬⣿⣿⣿⣿⣿⣿⡿⠳⠇⢙⣙⣽⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣯⣾⣎⣯⠈⠀⠀⠀⠀⠱⣷⣿⣿⣿⣿⢏⣿⣀⠀⠇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
- * ⠀⣸⣿⣿⣿⣿⣿⣿⣿⣿⠿⠁⠀⡬⣿⣿⣿⣿⣷⣿⣿⣿⠋⠀⢚⣝⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣯⣎⠈⢈⠈⠀⠀⠱⣿⣿⣿⣿⣿⣰⠀⣀⠩⠄⠀⠀⠀⠀⠀⠀⠀⠀
- * ⣀⣿⣿⣿⣿⣿⣷⣿⣿⠿⠀⢀⠶⣬⣿⣿⡷⠓⣾⣿⣿⣏⣬⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣯⢪⠀⠀⠐⣷⣿⣿⣿⠞⠈⣼⣿⠌⠀⠀⠀⠀⠀⠀⠀⠀
- * ⣸⣿⣿⣿⡿⢁⣿⣿⠓⠀⣀⢀⣼⣩⣿⣿⢌⣼⣻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠄⠀⠀⠀⠐⣿⣿⣿⣿⠌⠷⣿⠏⠀⠀⠀⠀⠀⠀⠀⠀
- * ⣿⣿⣿⣿⣯⣿⣿⢏⠀⠀⠀⠳⢓⣿⣿⠟⣹⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣮⣌⠈⠀⡰⣿⣿⣿⣯⠃⡰⠇⠀⠀⠀⠀⠀⠀⠀⠀
- * ⣿⣿⣿⣿⣿⣿⣿⡿⠳⢀⠜⣳⣿⣿⡳⣬⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠳⣿⣿⣿⣿⣿⣿⣿⢿⠃⠀⠀⣳⣿⣿⡿⣬⠀⣷⣮⢯⠈⠀⠀⠀⠀⠀
- * ⣿⣿⣿⣿⣿⣿⣿⠃⢐⣿⠷⣿⡿⣉⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠿⠓⠓⠓⠀⠀⠰⠑⣿⠓⣿⣿⠿⣳⠁⠀⠀⣰⣿⣿⣃⣿⠀⡰⣷⣿⣱⠀⠀⠀⠀⠀
- * ⣿⣿⣿⣿⣿⡿⠁⠀⠀⠑⣿⢗⣸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⡳⠀⠀⠀⠀⠈⣀⢌⠀⠀⠀⠁⡰⣷⣿⠃⠀⢀⠀⠀⣰⣿⣿⣿⣿⠀⠀⣼⣿⡿⠀⠀⠀⠀⠀
- * ⣿⣿⣿⣿⣿⠃⡀⠀⢀⢎⠀⡸⣷⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣯⣌⣌⣎⢌⢈⠈⠀⠀⢘⠀⠀⠀⠀⠀⠀⠀⠀⠀⣼⠀⠀⣾⣿⣿⣿⣿⢌⣾⣿⣿⠏⠀⠀⠀⠀⠀
- * ⣿⣿⣿⣿⡿⢀⠌⣠⡿⠁⠐⣡⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣝⣙⠝⣽⢟⢝⢀⠁⠑⡣⡦⠓⠀⠀⠀⠀⠀⠀⠀⢀⣼⠏⠀⣨⣿⣿⣿⣿⣿⣿⣿⣿⣿⣃⠀⠀⠀⠀⠀
- * ⣷⣿⣿⣿⠏⣼⠀⣸⢇⠀⣈⣷⡿⣳⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡹⣓⣟⠐⠀⠀⠀⢀⣮⣿⣿⣿⣿⣾⣬⢟⠈⠁⠀⣿⣿⣿⣿⣿⣿⠻⣿⣿⣿⢟⠌⠀⡠⣏⠀
- * ⣾⣿⣿⣿⠏⠏⠌⣿⠞⣨⠗⣼⠉⠓⣼⣷⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣯⣾⣿⣎⠈⠀⣈⣿⣿⣿⣿⣿⣷⣿⣿⣿⣿⠀⠀⣿⣿⣿⠟⠟⣕⠁⠐⡳⣿⣿⠋⣈⣮⠌⠀
- * ⣿⣿⣿⣿⣿⠏⣯⣿⣫⣿⠾⠀⠀⠘⡻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠷⢳⠳⡳⣿⣿⣿⣿⣯⣿⣿⣿⣿⠷⠇⠀⡰⠰⣿⣿⣿⠆⠀⣿⣿⣿⣿⣿⣾⠎⠀⠀⣱⣿⣿⣿⣿⠏⠀
- * ⣰⣿⣿⣿⣷⠇⡿⣷⣿⣿⣧⡧⡦⣷⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⣿⣿⣿⣿⣿⠣⠁⠀⠀⠀⠀⣷⣿⣿⣿⣿⣿⣿⡿⠇⠀⠀⠀⠀⠀⣰⣿⣿⠎⠀⣿⣿⣿⣿⣿⣿⣯⠀⠀⠀⣿⣿⣿⣿⠂⠀
- * ⣰⣿⣿⣿⠄⣨⣯⣾⣿⣿⠀⠀⢀⡾⣹⣿⣿⣿⣿⣿⣿⣿⢓⣶⣿⣿⣿⣿⠝⠀⠀⠀⠀⠀⢀⣠⣿⣿⣿⣷⣿⣿⠏⠀⠀⠀⠀⠀⠀⠀⣿⣿⣿⠈⡱⣿⣿⣿⣿⣿⠟⣎⠀⠀⣿⣿⣿⣿⠏⠀
- * ⠾⣿⣿⣿⠎⣿⣿⣿⣿⢟⡜⠆⠸⠱⣿⣿⣿⣿⣿⣿⡿⠁⠀⣿⣿⣿⣿⣿⠀⠀⠀⠀⠀⠀⠀⣸⣿⠷⠁⠒⠑⣿⠏⠀⠀⠀⠀⠀⠀⣰⣿⣿⣿⠁⠀⣳⣿⣿⣿⣿⣏⣷⠎⠀⣿⣿⣿⣿⠏⠀
- * ⣿⣿⣿⣿⠌⣱⣿⣿⣿⣿⠏⢀⣦⣾⣿⣿⣿⣿⣿⠿⣀⠀⢎⣼⣿⣿⣿⣿⠀⠀⠀⠀⠀⡈⠀⣿⣿⠗⠀⠀⠀⣰⣿⠈⠀⠀⠀⠀⠠⣿⣿⣿⠗⠀⠀⠰⣿⣿⣿⣿⣿⣾⠏⣰⣿⣿⠉⠐⠀⡏
- * ⣿⣿⣿⣿⠉⣰⣿⣿⣿⣿⣿⣾⣿⣿⣼⣿⣿⣿⣿⢃⠀⠀⣿⣻⣿⣿⣿⣿⣈⠈⠀⠀⠀⠀⣼⣿⣿⣿⢎⠀⣬⠐⠀⠁⣀⢌⠀⣀⣿⣿⣿⠷⠀⠀⠀⠀⣳⣿⣿⣿⣷⡿⣫⣿⣿⣿⠏⠀⠀⡀
- * ⣿⣿⣿⣿⠏⣰⣿⣿⣿⣿⣿⣿⣷⣿⣿⣿⣿⣿⠏⠀⠀⡀⣫⣿⣿⣿⣿⣿⣿⣿⣿⣼⣯⣿⣿⣿⣿⣿⣿⣾⠆⠀⠀⠀⠐⣿⣿⣿⣿⣿⢷⠀⠀⠀⠀⠀⣸⣿⣿⠟⠐⣿⣿⣿⣿⣿⠏⠀⠀⠀
- * ⣿⣿⣿⣿⣿⠐⢏⠏⣿⣿⣿⣿⠰⡿⣿⣷⣿⣿⠁⠀⢀⠀⣳⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣳⣿⣿⠿⠀⠀⠀⠀⠀⣿⣿⣿⣿⡟⠀⠀⠀⠀⠀⣀⣿⣿⣿⠀⠀⣰⣿⡿⣷⣿⠃⠀⠀⠀
- * ⣿⣿⣿⣿⣿⣠⣾⠁⠏⠗⣿⠏⠀⠀⢏⣰⠟⠐⠏⠀⠀⠀⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠇⣿⣿⣿⠏⠀⠀⠀⠀⣠⣿⣿⡿⠑⠀⠀⠀⠀⠀⢀⣾⣿⣿⠿⠀⠀⣰⣿⣿⣆⠐⢷⠀⠀⠀
- * ⣳⣿⣿⣿⣿⠰⣿⢌⠑⠆⠟⣳⠀⠀⠑⠐⠁⠀⢀⠀⠀⠀⠱⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠓⣰⣿⣿⣿⣏⣌⢌⠀⣠⣿⣿⠿⠁⠀⠀⠀⠀⠀⣈⣾⣿⣿⣿⢟⠈⠀⣼⣿⣿⠀⠀⠀⠀⠀⠀
- * ⣾⣿⣿⣿⣿⠏⣿⣿⠏⡦⠀⠱⠀⠀⣰⠈⡀⠀⣸⠌⠀⡀⠀⣿⣳⣿⣿⣿⣿⣿⣿⠿⡻⠁⣨⣿⣿⣿⣿⣿⣿⣿⡌⠌⣰⣿⠃⠀⠀⠀⠀⣌⣾⣿⣿⣿⣿⣿⣷⠀⣀⣿⣿⣿⠃⠀⠀⠀⠀⠀
- * ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣯⡈⠀⠄⠀⠠⣀⠀⡤⣿⣯⠌⠠⠠⠀⠒⡷⡷⣿⡿⠳⠀⠀⢀⣬⣿⣿⣿⣿⣿⣿⣿⣿⣯⢌⣰⢟⠀⠀⠀⠀⢀⣿⣿⣿⣿⣿⣿⠗⠂⣨⣿⣿⣿⣿⠏⠀⠀⠀⠀⠀
- * ⣿⣿⣿⡿⣿⣿⣿⣿⣿⣿⣿⣯⢌⢌⢈⣨⣨⢀⣿⣿⣿⣮⣬⠌⠎⠀⠀⠀⠀⠀⢀⣬⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣯⣎⠀⠀⠀⣼⣿⣿⣿⣿⠗⡿⢀⣾⣿⠿⣿⣿⡿⠁⠀⠀⠀⠀⠀
- * ⣿⣿⣿⠇⡰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠏⣼⣿⣿⣿⣿⣿⣿⣍⠀⠈⣌⢀⠌⣾⢓⠗⣿⣿⣿⣿⣿⣿⣿⣿⡷⣷⠷⣿⡿⠁⠀⠀⣼⣿⣿⣿⡽⢃⢸⣭⣿⣿⣿⣏⣱⣿⢉⠎⠲⠀⠀⠀⠀
- * ⣷⣿⣟⠀⢀⣰⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀⣿⣿⣿⣿⡳⣿⣿⣿⠃⠁⠑⡰⣷⣿⣾⠀⠐⠀⣱⣿⠿⠁⡾⠷⠀⠀⡠⠓⠀⠀⢈⠀⡱⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠄⣿⣿⠏⠀⠀⠀⠀⠀
- * ⣼⣿⣿⠀⠀⣰⣿⣿⣿⣿⣿⣿⡿⣿⣿⣿⠀⠷⣽⣿⣿⢎⠃⣱⣿⢎⢈⣈⢈⠀⠀⠑⠀⠀⢀⠀⢓⢀⠀⢈⠈⠀⢀⢈⠀⠐⣯⣿⠏⠀⣷⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀⣼⣿⠏⠂⠀⠀⠀⠀
- * ⣿⣿⣿⣏⠈⡰⣿⣿⣿⣿⣿⣿⠀⣿⣿⡿⣰⣀⠿⣿⣿⣿⣏⠘⣳⣿⣿⣿⣿⣮⣜⣬⣮⣞⣿⣯⣿⣿⣏⣿⣿⣿⣾⣿⣿⣿⣿⣿⣯⠀⣰⣿⣿⣿⣿⣿⣿⣿⣿⠗⠃⠀⣿⣿⠏⠀⠀⠀⠀⠀
- * ⣱⣿⣿⣿⣿⣮⠽⡳⣿⣿⣿⠏⠀⣿⣿⣯⢘⣰⣁⣇⠿⣼⣿⣿⠞⠱⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀⣰⣿⣿⣿⣿⠀⡰⠓⠑⠀⠀⣼⣿⣿⠃⠀⠀⠀⠀⠀
- * ⢰⣿⣿⣿⣿⣿⠏⣳⣿⣿⣿⣿⠀⣷⣿⣿⣿⠀⠸⣰⠀⢟⣱⣿⣿⣎⣸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠀⣿⣿⣿⣿⠏⠀⠀⠀⠀⡌⠀⣰⣿⠃⠀⠀⠀⠀⠀⠀
- * ⣰⣿⣿⡿⡾⣷⣯⣰⣿⣿⣿⣿⣎⣸⣿⣿⣿⣯⠏⣰⠀⠏⣼⣿⣷⣷⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⡷⠓⠀⣀⣿⣿⣿⠗⠀⠀⣈⠮⠳⠉⠀⣼⠃⠀⠀⠀⠀⠀⠀⠀
- * ⣰⣿⣿⠎⠀⡰⣿⣟⣷⣿⣿⣿⣿⠟⡰⣳⣿⣿⣿⣾⣈⠏⣳⠳⡰⠰⡷⣳⠗⠷⡷⣿⣿⣿⣿⣿⣿⣿⠷⡷⡷⠳⠳⠳⠑⠁⠀⠀⣨⣿⣿⣿⠏⠂⣠⡴⠓⠀⠀⠀⠴⠁⠀⠀⠀⠀⠀⠀
- * TODO: delete this function when this fix reaches stable version of tendermint⠀⠀
- */
-func setupProxy(targetAddr string, logger *zap.Logger) (string, error) {
-	targetUrl, err := url.Parse(targetAddr)
-	if err != nil {
-		return "", fmt.Errorf("%s is not a valid url: %w", targetAddr, err)
-	}
-
-	if targetUrl.Scheme == "tcp" {
-		targetUrl.Scheme = "http"
-	}
-	proxy := httputil.NewSingleHostReverseProxy(targetUrl)
-	originalDirector := proxy.Director
-	proxy.Director = func(request *http.Request) {
-		originalDirector(request)
-		request.Host = targetUrl.Host
-	}
-
-	listener, err := net.Listen("tcp4", "127.0.0.1:0")
-	if err != nil {
-		return "", fmt.Errorf("failed to bind to random port on 127.0.0.1: %w", err)
-	}
-
-	proxyAddr := fmt.Sprintf("http://%s", listener.Addr().String())
-	go func() {
-		err := http.Serve(listener, proxy)
-		if err != nil {
-			logger.Fatal("tendermint-workaround reverse proxy has failed", zap.Error(err))
-		}
-	}()
-
-	logger.Warn("set up tendermint-workaround proxy",
-		zap.String("target", targetAddr),
-		zap.String("listen", proxyAddr),
-	)
-	return proxyAddr, nil
 }


### PR DESCRIPTION
This workaround was needed to connect to https endpoints. We are using tendermint v0.34.24, which has a corresponding fix applied in https://github.com/tendermint/tendermint/pull/9416.

Also run `go mod tidy`.